### PR TITLE
Add TCL_LIBRARY environment variable and copy the additional headers (needed by expect)

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -14,6 +14,24 @@ export ZOPEN_CHECK_OPTS='test'
 rm -f tcl-core8.6.12-src
 ln -s tcl8.6.12 tcl-core8.6.12-src
 
+zopen_append_to_env() 
+{
+cat <<EOF
+export TCL_LIBRARY="\$PWD/lib/tcl8.6"
+EOF
+}
+
+zopen_post_install()
+{
+  set -e
+  install_dir=$1
+  echo $install_dir
+  echo $PWD
+  cp ../generic/*.h $install_dir/include
+  cp *.h $install_dir/include
+  set +e
+}
+
 zopen_check_results()
 {
   return 3 # non-functional


### PR DESCRIPTION
* TCL_LIBRARY is needed to locate tclinit 
* The additional generic/unix headers are needed during the build of expect.