### PR TITLE
Add version info to tcl

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -37,3 +37,7 @@ zopen_check_results()
   return 3 # non-functional
 }
 
+zopen_get_version()
+{
+  echo 'puts [info patchlevel];exit 0' | ./tclsh
+}


### PR DESCRIPTION
There's no --version option, used this answer: https://stackoverflow.com/questions/9200108/get-the-version-of-tcl-from-the-command-line